### PR TITLE
Enhance Rust dependencies in env_templates.py

### DIFF
--- a/src/env_templates.py
+++ b/src/env_templates.py
@@ -43,6 +43,7 @@ TEMPLATES = {
             modal.Image.from_registry("rust:slim")
             .apt_install("build-essential")
             .run_commands("cargo new app --bin")
+            .run_commands("cargo add async-trait serde anyhow async-openai") # P5297
             .workdir("/app")
         ),
         install_packages=lambda image, packages: image.run_commands(f"cargo add {' '.join(packages)}"),


### PR DESCRIPTION
Add Rust dependencies to the `rust` environment template in `src/env_templates.py`.

* Add `async-trait`, `serde`, `anyhow`, and `async-openai` to the `Cargo.toml` dependencies.
* Ensure the `rust` environment template installs these dependencies using the `cargo add` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/StudyHallAI/devlooper?shareId=XXXX-XXXX-XXXX-XXXX).